### PR TITLE
Fix Typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ In order to have similar experience to the [preview](#filament-translatable-tabs
 TranslatableTabs::configureUsing(function (TranslatableTabs $component) {
     $component
         ->addDirectionByLocale()
-        ->addEmptyBadgeWhenAllFieldsAreEmpty(emptyLabel: __('locales.empty'))
+        ->addEmptyBadgeWhenAllFieldsAreEmpty(emptyLable: __('locales.empty'))
         ->addSetActiveTabThatHasValue();
 });
 ```

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ In order to have similar experience to the [preview](#filament-translatable-tabs
 TranslatableTabs::configureUsing(function (TranslatableTabs $component) {
     $component
         ->addDirectionByLocale()
-        ->addEmptyBadgeWhenAllFieldsAreEmpty(emptyLable: __('locales.empty'))
+        ->addEmptyBadgeWhenAllFieldsAreEmpty(emptyLabel: __('locales.empty'))
         ->addSetActiveTabThatHasValue();
 });
 ```

--- a/src/HasExtraConfigs.php
+++ b/src/HasExtraConfigs.php
@@ -16,16 +16,16 @@ trait HasExtraConfigs
         return $this;
     }
 
-    public function addEmptyBadgeWhenAllFieldsAreEmpty(string $emptyLable): static
+    public function addEmptyBadgeWhenAllFieldsAreEmpty(string $emptyLabel): static
     {
-        $this->modifyTabsUsing(function (TranslatableTab $component, string $locale) use ($emptyLable) {
+        $this->modifyTabsUsing(function (TranslatableTab $component, string $locale) use ($emptyLabel) {
             $hasValue = fn ($tab, $get): bool => collect($tab->getChildComponents())
                 ->contains(fn ($c) => ! empty($get($c->getName())));
 
             $component
                 ->live(true)
                 ->badgeColor(fn ($component, $get) => $hasValue($component, $get) ? null : 'warning')
-                ->badge(fn ($component, $get) => $hasValue($component, $get) ? null : $emptyLable);
+                ->badge(fn ($component, $get) => $hasValue($component, $get) ? null : $emptyLabel);
         });
 
         return $this;


### PR DESCRIPTION
This pull request includes a minor correction to the `README.md` file. The change fixes a typo in the `TranslatableTabs::configureUsing` function call.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L133-R133): Corrected the parameter name from `emptyLabel` to `emptyLable` in the `addEmptyBadgeWhenAllFieldsAreEmpty` method.