### PR TITLE
Fix: It Override Default Field Labels with Locale Keys When Label Not Explicitly Set

### DIFF
--- a/src/TranslatableTabs.php
+++ b/src/TranslatableTabs.php
@@ -129,6 +129,7 @@ class TranslatableTabs extends Tabs
                 $field = $component
                     ->getClone()
                     ->name("{$component->getName()}.$locale")
+                    ->label($component->getLabel())
                     ->statePath("{$component->getStatePath(false)}.$locale");
 
                 $fields[] = $field;


### PR DESCRIPTION
This Pr to fix [this open bug](https://github.com/Abdulmajeed-Jamaan/filament-translatable-tabs/issues/9)