### PR TITLE
Add RichEditor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,21 @@ TranslatableTabs::configureUsing(function (TranslatableTabs $component) {
 });
 ```
 
+### Rich Editor support
+
+When the `Filament\Forms\Components\RichEditor` field is empty it actually still contains a `<p></p>` tag.
+To make TranslatableTabs consider this condition as an empty field, and to save the empty value/translation to the database as `null`, add `addConvertRichEditorEmptyPTagToNull()` to `configureUsing`.
+
+
+```php
+TranslatableTabs::configureUsing(function (TranslatableTabs $component) {
+    $component
+        ->addDirectionByLocale()
+        ->addEmptyBadgeWhenAllFieldsAreEmpty(emptyLabel: __('locales.empty'))
+        ->addSetActiveTabThatHasValue()
+        ->addConvertRichEditorEmptyPTagToNull();
+});
+```
 
 ## Changelog
 

--- a/src/HasExtraConfigs.php
+++ b/src/HasExtraConfigs.php
@@ -3,9 +3,13 @@
 namespace AbdulmajeedJamaan\FilamentTranslatableTabs;
 
 use Filament\Forms\Components\Field;
+use Filament\Forms\Components\RichEditor;
+use Filament\Forms\Components\RichEditor\RichContentRenderer;
 
 trait HasExtraConfigs
 {
+    private bool $handleRichEditor = false;
+
     public function addDirectionByLocale(): static
     {
         $this->modifyFieldsUsing(function (Field $component, string $locale) {
@@ -16,11 +20,32 @@ trait HasExtraConfigs
         return $this;
     }
 
+    public function addConvertRichEditorEmptyPTagToNull(): static
+    {
+        $this->handleRichEditor = true;
+
+        $this->modifyFieldsUsing(function (Field $component, string $locale) {
+            if ($component instanceof RichEditor) {
+                $component->dehydrateStateUsing(function ($state) {
+                    return $state == '<p></p>' ? null : $state;
+                });
+            }
+        });
+
+        return $this;
+    }
+
     public function addEmptyBadgeWhenAllFieldsAreEmpty(string $emptyLabel): static
     {
         $this->modifyTabsUsing(function (TranslatableTab $component, string $locale) use ($emptyLabel) {
             $hasValue = fn ($tab, $get): bool => collect($tab->getChildComponents())
-                ->contains(fn ($c) => ! empty($get($c->getName())));
+                ->contains(function ($c) use ($get) {
+                    $content = $get($c->getName());
+                    if ($this->handleRichEditor && $c instanceof RichEditor) {
+                        return $content != '<p></p>';
+                    }
+                    return ! empty($content);
+                });
 
             $component
                 ->live(true)
@@ -36,7 +61,13 @@ trait HasExtraConfigs
         $this->activeTab(function ($get, $component) {
             $hasValue = function ($tab, $get): bool {
                 foreach ($tab->getChildComponents() as $component) {
-                    if (! empty($get($component->getName()))) {
+                    $content = $get($component->getName());
+                    if ($this->handleRichEditor && $component instanceof RichEditor) {
+                        $html = RichContentRenderer::make($content)->toHtml();
+                        if ($html != '<p></p>') {
+                            return true;
+                        }
+                    } else if (! empty($content)) {
                         return true;
                     }
                 }


### PR DESCRIPTION
Filament's `Filament\Forms\Components\RichEditor` is never actually 'empty' - it always contains at the very least an empty `<p></p>` tag. This prevents the `addEmptyBadgeWhenAllFieldsAreEmpty()` and `addSetActiveTabThatHasValue()` functions from working properly with `RichEditor` fields.

This PR adds support for `RichEditor` fields by detecting the empty `<p>` tag in `RichEditor` fields and treating that as 'empty'. Additionally, a field with an empty `<p>` tag for a given translation will be converted to `null` using Filament's `dehydrateStateUsing` functionality. This ensures that the translation is saved as `null` in the database, which is required for packages such as `spatie/laravel-translatable` to correctly detect the missing translation and fallback to the site locale in functions such as `getTranslation()`.

The functionality is OFF by default, and can be enabled by adding `addConvertRichEditorEmptyPTagToNull()` to the `TranslatableTabs::configureUsing` block.