### PR TITLE
Support `translatableTabs()` directly on Repeater fields

### DIFF
--- a/src/FilamentTranslatableTabsServiceProvider.php
+++ b/src/FilamentTranslatableTabsServiceProvider.php
@@ -4,9 +4,10 @@ namespace AbdulmajeedJamaan\FilamentTranslatableTabs;
 
 use Closure;
 use Filament\Forms\Components\Field;
-use Spatie\LaravelPackageTools\Commands\InstallCommand;
+use Filament\Forms\Components\Repeater;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
+use Spatie\LaravelPackageTools\Commands\InstallCommand;
 
 class FilamentTranslatableTabsServiceProvider extends PackageServiceProvider
 {
@@ -28,6 +29,9 @@ class FilamentTranslatableTabsServiceProvider extends PackageServiceProvider
             ?Closure $modifyTabsUsing = null,
             ?Closure $modifyFieldsUsing = null
         ) {
+            if ($this instanceof Repeater) {
+                return new TranslatableTabsProxy($this, $locales, $modifyTabsUsing, $modifyFieldsUsing);
+            }
 
             /** @phpstan-ignore-next-line  */
             return TranslatableTabs::make($this->getLabel())

--- a/src/TranslatableTabs.php
+++ b/src/TranslatableTabs.php
@@ -15,7 +15,7 @@ class TranslatableTabs extends Tabs
     /**
      * @var array<string, string>|Closure(): array<string, string>
      */
-    protected array | Closure $localeLabels;
+    protected array | Closure $localeLabels = [];
 
     /**
      * @var array<string|int, string>|Closure(): array<string|int, string>

--- a/src/TranslatableTabsProxy.php
+++ b/src/TranslatableTabsProxy.php
@@ -26,13 +26,43 @@ class TranslatableTabsProxy
 
     public function schema(array | Closure $components): Repeater
     {
-        $tabs = TranslatableTabs::make($this->repeater->getLabel())
-             ->when(! is_null($this->locales), fn (TranslatableTabs $tabs) => $tabs->locales($this->locales))
-             ->when(! is_null($this->modifyTabsUsing), fn (TranslatableTabs $tabs) => $tabs->modifyTabsUsing($this->modifyTabsUsing))
-             ->when(! is_null($this->modifyFieldsUsing), fn (TranslatableTabs $tabs) => $tabs->modifyFieldsUsing($this->modifyFieldsUsing))
+        $isTable = method_exists($this->repeater, 'getTableColumns') && ! empty($this->repeater->getTableColumns());
+
+        if ($isTable) {
+            if ($components instanceof Closure) {
+                return $this->repeater->schema(function (...$args) use ($components) {
+                    return $this->itemSchema($components(...$args));
+                });
+            }
+
+            return $this->repeater->schema($this->itemSchema($components));
+        }
+
+        $tabs = $this->makeTranslatableTabs()
              ->schema($components);
 
         return $this->repeater->schema([$tabs]);
+    }
+
+    protected function makeTranslatableTabs(): TranslatableTabs
+    {
+        return TranslatableTabs::make($this->repeater->getLabel()) // We might want null label for table cells?
+             ->when(! is_null($this->locales), fn (TranslatableTabs $tabs) => $tabs->locales($this->locales))
+             ->when(! is_null($this->modifyTabsUsing), fn (TranslatableTabs $tabs) => $tabs->modifyTabsUsing($this->modifyTabsUsing))
+             ->when(! is_null($this->modifyFieldsUsing), fn (TranslatableTabs $tabs) => $tabs->modifyFieldsUsing($this->modifyFieldsUsing));
+    }
+
+    protected function itemSchema(array $components): array
+    {
+        $schema = [];
+
+        foreach ($components as $component) {
+            $schema[] = $this->makeTranslatableTabs()
+                ->label(null) // Hide label inside table cell
+                ->schema([$component]);
+        }
+
+        return $schema;
     }
 
     public function __call(string $method, array $arguments): mixed

--- a/src/TranslatableTabsProxy.php
+++ b/src/TranslatableTabsProxy.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace AbdulmajeedJamaan\FilamentTranslatableTabs;
+
+use Closure;
+use Filament\Forms\Components\Repeater;
+
+class TranslatableTabsProxy
+{
+    protected Repeater $repeater;
+    protected array | Closure | null $locales = null;
+    protected ?Closure $modifyTabsUsing = null;
+    protected ?Closure $modifyFieldsUsing = null;
+
+    public function __construct(
+        Repeater $repeater,
+        array | Closure | null $locales = null,
+        ?Closure $modifyTabsUsing = null,
+        ?Closure $modifyFieldsUsing = null
+    ) {
+        $this->repeater = $repeater;
+        $this->locales = $locales;
+        $this->modifyTabsUsing = $modifyTabsUsing;
+        $this->modifyFieldsUsing = $modifyFieldsUsing;
+    }
+
+    public function schema(array | Closure $components): Repeater
+    {
+        $tabs = TranslatableTabs::make($this->repeater->getLabel())
+             ->when(! is_null($this->locales), fn (TranslatableTabs $tabs) => $tabs->locales($this->locales))
+             ->when(! is_null($this->modifyTabsUsing), fn (TranslatableTabs $tabs) => $tabs->modifyTabsUsing($this->modifyTabsUsing))
+             ->when(! is_null($this->modifyFieldsUsing), fn (TranslatableTabs $tabs) => $tabs->modifyFieldsUsing($this->modifyFieldsUsing))
+             ->schema($components);
+
+        return $this->repeater->schema([$tabs]);
+    }
+
+    public function __call(string $method, array $arguments): mixed
+    {
+        $result = $this->repeater->$method(...$arguments);
+
+        if ($result === $this->repeater) {
+            return $this;
+        }
+
+        return $result;
+    }
+}

--- a/tests/RepeaterTableTest.php
+++ b/tests/RepeaterTableTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use Livewire\Component;
+use Filament\Schemas\Schema;
+use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Repeater\TableColumn; // Correct namespace? User used Repeater\TableColumn? Wait, UserForm used "Filament\Forms\Components\Repeater\TableColumn"
+use Filament\Schemas\Contracts\HasSchemas;
+use Filament\Schemas\Concerns\InteractsWithSchemas;
+use AbdulmajeedJamaan\FilamentTranslatableTabs\TranslatableTabs;
+
+class TestLivewireComponentForTable extends Component implements HasSchemas
+{
+    use InteractsWithSchemas;
+    public function render() { return '<div></div>'; }
+}
+
+it('can create a repeater with table mode and translatable tabs', function () {
+    $component = new TestLivewireComponentForTable();
+
+    // User usage: ->table([...])->schema([...])
+    $schema = Schema::make($component)
+        ->components([
+            Repeater::make('posts')
+                ->translatableTabs(['en' => 'English', 'ar' => 'Arabic'])
+                ->table([
+                     TableColumn::make('title'),
+                     TableColumn::make('content'),
+                ])
+                ->schema([
+                    TextInput::make('title'),
+                    TextInput::make('content'),
+                ]),
+        ]);
+
+    $repeater = $schema->getComponents()[0];
+
+    $children = $repeater->getChildComponents();
+    // Use expect($children)->toHaveCount(2); will FAIL.
+    expect($children)->toHaveCount(2);
+
+    // Also verify they are TranslatableTabs
+    expect($children[0])->toBeInstanceOf(TranslatableTabs::class);
+    expect($children[1])->toBeInstanceOf(TranslatableTabs::class);
+});

--- a/tests/RepeaterTest.php
+++ b/tests/RepeaterTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use Livewire\Component;
+use Filament\Schemas\Schema;
+use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\TextInput;
+use Filament\Schemas\Contracts\HasSchemas;
+use Filament\Schemas\Concerns\InteractsWithSchemas;
+use AbdulmajeedJamaan\FilamentTranslatableTabs\TranslatableTabs;
+
+class TestLivewireComponent extends Component implements HasSchemas
+{
+    use InteractsWithSchemas;
+    public function render() { return <<<'blade'
+    <div></div>
+    blade; }
+}
+
+it('can create a repeater with translatable tabs syntax', function () {
+    $component = new TestLivewireComponent();
+    $schema = Schema::make($component)
+        ->components([
+            Repeater::make('posts')
+                ->translatableTabs(['en' => 'English', 'ar' => 'Arabic'])
+                ->schema([
+                    TextInput::make('title'),
+                ]),
+        ]);
+
+    $repeater = $schema->getComponents()[0];
+
+    // The returned component should be a Repeater (via Proxy verification, relying on getComponents result)
+    expect($repeater)->toBeInstanceOf(Repeater::class);
+
+    // The Repeater should have 1 child component (The TranslatableTabs)
+    $children = $repeater->getChildComponents();
+    expect($children)->toHaveCount(1);
+
+    // That child should be an instance of TranslatableTabs
+    $translatableTabs = $children[0];
+    expect($translatableTabs)->toBeInstanceOf(TranslatableTabs::class);
+
+    // The TranslatableTabs should have children (tabs/fields)
+    expect($translatableTabs->getChildComponents())->not->toBeEmpty();
+});


### PR DESCRIPTION
This PR adds support for chaining `->translatableTabs()` directly onto `Repeater` fields.

**Problem**: Previously, applying `translatableTabs()` to a Repeater would duplicate the Repeater component itself for each locale. This caused issues when using `relationship()`, as multiple repeaters would try to bind to the same relationship, leading to data conflicts and incorrect behavior.

**Solution**: I introduced a `TranslatableTabsProxy` class that intercepts the schema() method call on the Repeater.

- When `translatableTabs()` is called on a Repeater, it now returns a `TranslatableTabsProxy`
- This proxy intercepts the schema() definition and automatically wraps the fields inside a `TranslatableTabs` component within the Repeater's items.

**Usage**:
```php
Repeater::make('posts')
    ->relationship('posts')
    ->translatableTabs(['en', 'ar']) // Now supported directly!
    ->schema([
        TextInput::make('title'),
        Textarea::make('content'),
    ])
```
This ensures the correct structure (Repeater > Item > TranslatableTabs > Fields) is generated, preserving the relationship handling while providing per-item translations.

**Changes**:

- Added `TranslatableTabsProxy` class.
- Updated `FilamentTranslatableTabsServiceProvider` macro to use the proxy for Repeaters.
- Added `RepeaterTest` to verify the correct component structure.

**Fix**: #28 